### PR TITLE
予測検索

### DIFF
--- a/backend-ts/src/employee/EmployeeDatabaseDynamoDB.ts
+++ b/backend-ts/src/employee/EmployeeDatabaseDynamoDB.ts
@@ -1,73 +1,92 @@
-import { DynamoDBClient, GetItemCommand, GetItemCommandInput, ScanCommand, ScanCommandInput } from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBClient,
+  GetItemCommand,
+  GetItemCommandInput,
+  ScanCommand,
+  ScanCommandInput,
+} from "@aws-sdk/client-dynamodb";
 import { isLeft } from "fp-ts/Either";
 import { EmployeeDatabase } from "./EmployeeDatabase";
 import { Employee, EmployeeT } from "./Employee";
 
 export class EmployeeDatabaseDynamoDB implements EmployeeDatabase {
-    private client: DynamoDBClient;
-    private tableName: string;
+  private client: DynamoDBClient;
+  private tableName: string;
 
-    constructor(client: DynamoDBClient, tableName: string) {
-        this.client = client;
-        this.tableName = tableName;
+  constructor(client: DynamoDBClient, tableName: string) {
+    this.client = client;
+    this.tableName = tableName;
+  }
+
+  async getEmployee(id: string): Promise<Employee | undefined> {
+    const input: GetItemCommandInput = {
+      TableName: this.tableName,
+      Key: {
+        id: { S: id },
+      },
+    };
+    const output = await this.client.send(new GetItemCommand(input));
+    const item = output.Item;
+    if (item == null) {
+      return;
     }
+    const employee = {
+      id: id,
+      name: item["name"].S,
+      age: mapNullable(item["age"].N, (value) => parseInt(value, 10)),
+    };
+    const decoded = EmployeeT.decode(employee);
+    if (isLeft(decoded)) {
+      throw new Error(
+        `Employee ${id} is missing some fields. ${JSON.stringify(employee)}`
+      );
+    } else {
+      return decoded.right;
+    }
+  }
 
-    async getEmployee(id: string): Promise<Employee | undefined> {
-        const input: GetItemCommandInput  = {
-            TableName: this.tableName,
-            Key: {
-                id: { S: id },
-            },
+  async getEmployees(filterText: string): Promise<Employee[]> {
+    const input: ScanCommandInput = {
+      TableName: this.tableName,
+    };
+    const output = await this.client.send(new ScanCommand(input));
+    const items = output.Items;
+    if (items == null) {
+      return [];
+    }
+    return items
+      .filter((item) => {
+        const name = item["name"]?.S?.toLowerCase();
+        return filterText === "" || name?.includes(filterText.toLowerCase());
+      })
+      .map((item) => {
+        return {
+          id: item["id"].S,
+          name: item["name"].S,
+          age: mapNullable(item["age"].N, (value) => parseInt(value, 10)),
         };
-        const output = await this.client.send(new GetItemCommand(input));
-        const item = output.Item;
-        if (item == null) {
-            return;
-        }
-        const employee = {
-            id: id,
-            name: item["name"].S,
-            age: mapNullable(item["age"].N, value => parseInt(value, 10)),
-        };
+      })
+      .flatMap((employee) => {
         const decoded = EmployeeT.decode(employee);
         if (isLeft(decoded)) {
-            throw new Error(`Employee ${id} is missing some fields. ${JSON.stringify(employee)}`);
+          console.error(
+            `Employee ${
+              employee.id
+            } is missing some fields and skipped. ${JSON.stringify(employee)}`
+          );
+          return [];
         } else {
-            return decoded.right;
+          return [decoded.right];
         }
-    }
-
-    async getEmployees(filterText: string): Promise<Employee[]> {
-        const input: ScanCommandInput  = {
-            TableName: this.tableName,
-        };
-        const output = await this.client.send(new ScanCommand(input));
-        const items = output.Items;
-        if (items == null) {
-            return [];
-        }
-        return items
-            .filter(item => filterText === "" || item["name"].S === filterText)
-            .map(item => {
-                return {
-                    id: item["id"].S,
-                    name: item["name"].S,
-                    age: mapNullable(item["age"].N, value => parseInt(value, 10)),
-                }
-            }).flatMap(employee => {
-                const decoded = EmployeeT.decode(employee);
-                if (isLeft(decoded)) {
-                    console.error(`Employee ${employee.id} is missing some fields and skipped. ${JSON.stringify(employee)}`);
-                    return [];
-                } else {
-                    return [decoded.right];
-                }
-            });
-    }
+      });
+  }
 }
 
-function mapNullable<T, U>(value: T | null | undefined, mapper: (value: T) => U): U | undefined {
-    if (value != null) {
-        return mapper(value);
-    }
+function mapNullable<T, U>(
+  value: T | null | undefined,
+  mapper: (value: T) => U
+): U | undefined {
+  if (value != null) {
+    return mapper(value);
+  }
 }

--- a/backend-ts/src/employee/EmployeeDatabaseInMemory.ts
+++ b/backend-ts/src/employee/EmployeeDatabaseInMemory.ts
@@ -2,24 +2,26 @@ import { EmployeeDatabase } from "./EmployeeDatabase";
 import { Employee } from "./Employee";
 
 export class EmployeeDatabaseInMemory implements EmployeeDatabase {
-    private employees: Map<string, Employee>
+  private employees: Map<string, Employee>;
 
-    constructor() {
-        this.employees = new Map<string, Employee>();
-        this.employees.set("1", { id: "1", name: "Jane Doe", age: 22 });
-        this.employees.set("2", { id: "2", name: "John Smith", age: 28 });
-        this.employees.set("3", { id: "3", name: "山田 太郎", age: 27 });
-    }
+  constructor() {
+    this.employees = new Map<string, Employee>();
+    this.employees.set("1", { id: "1", name: "Jane Doe", age: 22 });
+    this.employees.set("2", { id: "2", name: "John Smith", age: 28 });
+    this.employees.set("3", { id: "3", name: "山田 太郎", age: 27 });
+  }
 
-    async getEmployee(id: string): Promise<Employee | undefined> {
-        return this.employees.get(id);
-    }
+  async getEmployee(id: string): Promise<Employee | undefined> {
+    return this.employees.get(id);
+  }
 
-    async getEmployees(filterText: string): Promise<Employee[]> {
-        const employees = Array.from(this.employees.values());
-        if (filterText === "") {
-            return employees;
-        }
-        return employees.filter(employee => employee.name === filterText);
+  async getEmployees(filterText: string): Promise<Employee[]> {
+    const employees = Array.from(this.employees.values());
+    if (filterText === "") {
+      return employees;
     }
+    return employees.filter((employee) =>
+      employee.name.toLowerCase().includes(filterText.toLowerCase())
+    );
+  }
 }


### PR DESCRIPTION
# 概要
検索時にincludeする文字の検索が引っかかるようにしました。

# 詳細
例:jana
検索結果
JanaMasa
janaHiro
小文字大文字の違いを考慮して検索できるようになるようにしました。
ただし、やまなどで、山田は引っかかりません。
# 生成AIの利用について
ChatGPT4.1検索で、
に当たる.fliterのコードを張り付けて、
"abc"と入力した際に"ABCDE"や"abc"が反応するようにコードを書き換えて
と入力し、出力を用いました。

